### PR TITLE
Added snippet for replaceOne() query and updated the snippet for updateOne() and updateMany() query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ All notable changes to the "mongo-snippets-for-node-js" extension will be docume
 
 - Allow mongo queries on display of Database as JSON
 
+- Feature: Add snippet for replaceOne() mongo query.
+- Fix: 
+   * snippet for updateOne() mongo query
+   * snippet for updateMany() mongo query
+
 ### v1.3.5
 
 - Fix:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The following are some of the snippets that can be generated with this extension
 |            1.            |    **!mdbf**   |         MongoDB Find        |       *Model.find* query       |
 |            2.            |   **!mdbfo**   |       MongoDB FindOne       |      *Model.findOne* query     |
 |            3.            |   **!mdbfbi**  |       MongoDB FindById      |     *Model.findById* query     |
+|        **Replace:**      |                |                             |                                |
+|            1.            |   **!mdbro**   |      MongoDB ReplaceOne     |     *Model.replaceOne* query   |
 |        **Update:**       |                |                             |                                |
 |            1.            |  **!mdbfoau**  |   MongoDB FindOneAndUpdate  | *Model.findOneAndUpdate* query |
 |            2.            |   **!mdbuo**   |      MongoDB UpdateOne      |     *Model.updateOne* query    |

--- a/src/snippets/snippets.json
+++ b/src/snippets/snippets.json
@@ -273,13 +273,29 @@
             "}, {",
             "    ${4:update-field}: ${5:filter}",
             "}",
-            "}, (err) => {",
+            "(err) => {",
             "   if(err){",    
             "       console.log(`Error: ` + err)",
             "   }",
             "});"
         ],
         "description": "Generates code for updateOne query in mongoose."
+    },
+    "MongoDB replaceOne": {
+        "prefix": "!mdbro",
+        "body": [
+            "${1:Model}.replaceOne({ ",
+            "    ${2:find-field}: ${3:filter}",
+            "}, {",
+            "    ${4:field}: ${5:value}",
+            "}",
+            " (err) => {",
+            "   if(err){",    
+            "       console.log(`Error: ` + err)",
+            "   }",
+            "});"
+        ],
+        "description": "Generates code for replaceOne query in mongoose."
     },
     "MongoDB updateMany": {
         "prefix": "!mdbum",
@@ -289,7 +305,7 @@
             "}, {",
             "    ${4:update-field}: ${5:filter}",
             "}",
-            "}, (err) => {",
+            "(err) => {",
             "   if(err){",    
             "       console.log(`Error: ` + err)",
             "   }",


### PR DESCRIPTION
Feature: Add snippet for replaceOne() mongo query. Fix: snippet for updateOne() mongo query, snippet for updateMany() mongo query

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Feature: Add snippet for replaceOne() mongo query. 
- Fix: 
* snippet for updateOne() mongo query
* snippet for updateMany() mongo query

* **What is the current behavior?** (You can also link to an open issue here)

Currently, there is no snippet for the replaceOne() query.
updateOne() snippet has a small bug in it. (an extra closing bracket and an extra comma (,))

* **What is the new behavior (if this is a feature change)?**

snippet for replaceOne() mongo query exists 
snippet for updateOne() mongo query has been fixed
snippet for updateMany() mongo query has been fixed

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

the {overwrite: true} option in the updateOne() query has been deprecated and users need to use the replaceOne() query in its place.

* **Other information**: